### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const createDirIfNotExist = to => {
 
 const findDestination = (from, entry) => path.join(entry.dest, path.relative(globParent(entry.files), from));
 
-module.exports = (paths, { watch = false, verbose = false } = {}) => {
+module.exports = (paths, { watch = !!process.env.ROLLUP_WATCH, verbose = false } = {}) => {
   const copy = async (from, entry) => {
     const to = findDestination(from, entry);
 


### PR DESCRIPTION
Watch `--watch` flag is coming from rollup it self. So in this case if I start rollup in watch mode it will respect that unless I specify directly that do not watch it

More info here: https://github.com/rollup/rollup-watch/issues/48#issuecomment-314889800